### PR TITLE
Add script for fetching markets and prices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # poly
+
+This repository provides a simple script to query Polymarket data.
+
+## fetch_markets.py
+
+`fetch_markets.py` ruft ueber die Gamma API aktive Maerkte ab, deren Startdatum nach dem 26. Juni 2025 liegt. Die gefundenen Maerkte werden ausgegeben und das Programm fragt, ob Preise ueber den CLOB Endpunkt abgefragt werden sollen. Bei Bestaetigung werden die Token der Maerkte abgefragt und die aktuellen Preise ausgegeben.
+
+### Nutzung
+
+1. Abhaengigkeit installieren:
+   ```bash
+   pip install requests
+   ```
+2. Script starten:
+   ```bash
+   python fetch_markets.py
+   ```

--- a/fetch_markets.py
+++ b/fetch_markets.py
@@ -1,0 +1,65 @@
+import requests
+from datetime import datetime
+from typing import List
+
+GAMMA_ENDPOINT = "https://gamma-api.polymarket.com/markets"
+CLOB_ENDPOINT = "https://clob.polymarket.com"
+
+
+def fetch_markets(start_date_min: str) -> List[dict]:
+    params = {
+        "active": "true",
+        "closed": "false",
+        "archived": "false",
+        "start_date_min": start_date_min,
+    }
+    resp = requests.get(GAMMA_ENDPOINT, params=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def fetch_tokens(condition_id: str) -> List[str]:
+    url = f"{CLOB_ENDPOINT}/markets/{condition_id}"
+    resp = requests.get(url)
+    resp.raise_for_status()
+    market = resp.json().get("market", {})
+    tokens = market.get("tokens", [])
+    return [t.get("token_id") for t in tokens]
+
+
+def fetch_prices(token_ids: List[str]) -> dict:
+    params = {"params": [{"token_id": tid, "side": "BUY"} for tid in token_ids]}
+    resp = requests.post(f"{CLOB_ENDPOINT}/prices", json=params)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def main():
+    start_date = "2025-06-27T00:00:00Z"
+    markets = fetch_markets(start_date)
+    if not markets:
+        print("Keine passenden Märkte gefunden.")
+        return
+
+    print("Gefundene Märkte:")
+    for m in markets:
+        print(f"- {m['id']}: {m['slug']} (Start: {m['start_date']})")
+
+    cont = input("Fortfahren und Preise abrufen? [j/N] ").strip().lower()
+    if cont != "j":
+        return
+
+    all_tokens = []
+    for m in markets:
+        tokens = fetch_tokens(str(m["id"]))
+        all_tokens.extend(tokens)
+
+    prices = fetch_prices(all_tokens)
+    print("Preise:")
+    for asset, sides in prices.items():
+        price = sides.get("BUY")
+        print(f"Token {asset}: {price}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `fetch_markets.py` which gets upcoming markets from the Gamma API and retrieves their token prices from the CLOB
- document usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860090699908328ab326c08c54d47b7